### PR TITLE
error handling when trying to convert a date to gregorian that cannot be converted

### DIFF
--- a/bsdate.go
+++ b/bsdate.go
@@ -10,7 +10,7 @@ type Date interface {
 	GetMonth() int
 	GetYear() int
 	GetMonthName() string
-	GetGregorianDate() time.Time
+	GetGregorianDate() (time.Time, error)
 }
 type date struct {
 	Day        int
@@ -270,7 +270,7 @@ func (d date) isValid() bool {
 	return true
 }
 
-func (d date) GetGregorianDate() time.Time  {
+func (d date) GetGregorianDate() (time.Time, error)  {
 	var daysAfterJanFirstOfGregorianYear = 0 //we will add all the days that went by since the 1st.
 	                                         //January and then we can get the gregorian Date
 	var gregorianYear int
@@ -299,6 +299,10 @@ func (d date) GetGregorianDate() time.Time  {
 		if nepaliMonthToCheck <= 0 {
 			nepaliMonthToCheck = 12
 			nepaliYearToCheck--
+			//do we have data of that year?
+			if _, ok := calendardata[nepaliYearToCheck]; !ok {
+				return time.Time{}, errors.New("cannot convert date, missing data")
+			}
 		}
 		daysAfterJanFirstOfGregorianYear += calendardata[nepaliYearToCheck][nepaliMonthToCheck]
 	}
@@ -323,5 +327,5 @@ func (d date) GetGregorianDate() time.Time  {
 
 	gregorianDate := time.Date(gregorianYear,1,1,0,0,0,0,time.UTC)
 	gregorianDate = gregorianDate.AddDate(0,0, daysAfterJanFirstOfGregorianYear)
-	return gregorianDate
+	return gregorianDate, nil
 }

--- a/bsdate_test.go
+++ b/bsdate_test.go
@@ -88,6 +88,7 @@ var convertedDates = []TestDateConversionStruc{
 	{"2076-02-01", "2019-05-15"}, //start of a month with 32 days
 	{"2076-02-32", "2019-06-15"}, //end of a month with 32 days
 	{"2076-03-01", "2019-06-16"}, //a month after a month with 32 days
+	{"2100-12-30", "2044-04-12"},
 }
 func TestValidBSDates(t *testing.T) {
 	for _, testCase := range validDates {
@@ -147,11 +148,35 @@ func TestConversionToGregorian(t *testing.T) {
 			nepaliDate, err := New(bsDay, bsMonth, bsYear)
 			assert.Equal(t, err, nil)
 
-			var convertedGregorianDate = nepaliDate.GetGregorianDate()
+			var convertedGregorianDate, _ = nepaliDate.GetGregorianDate()
 			expectedGregorianDate, _ := time.Parse("2006-01-02", testCase.gregorianDate)
 			assert.Equal(t, convertedGregorianDate, expectedGregorianDate)
 		})
 
+	}
+}
+
+//cannot convert anything before BS 1970-09-01 because for that we would need data from 1969
+var impossibleToConvertToGregorianDates = [] string {
+	"1970-01-01",
+	"1970-08-29",
+}
+func TestConversionInvalidToGregorian(t *testing.T) {
+	for _, testCase := range impossibleToConvertToGregorianDates {
+		t.Run(testCase, func(t *testing.T) {
+			var splitedBSDate = strings.Split(testCase, "-")
+			var bsDay, _ = strconv.Atoi(splitedBSDate[2])
+			var bsMonth, _ = strconv.Atoi(splitedBSDate[1])
+			var bsYear, _ = strconv.Atoi(splitedBSDate[0])
+
+			nepaliDate, err := New(bsDay, bsMonth, bsYear)
+			assert.Equal(t, err, nil)
+			var convertedGregorianDate time.Time
+			convertedGregorianDate, err = nepaliDate.GetGregorianDate()
+			expectedGregorianDate, _ := time.Parse("2006-01-02", "0001-01-01")
+			assert.Equal(t, err.Error(), "cannot convert date, missing data")
+			assert.Equal(t, convertedGregorianDate, expectedGregorianDate)
+		})
 	}
 }
 


### PR DESCRIPTION
converting anything before 1970-09-01 BS to gregorian is not possible, because that would need data from BS 1969, but still a valid BS date can be created with that data